### PR TITLE
fix: removed top margin causing interaction problem

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -241,7 +241,7 @@ body {
 	padding-top: 0 !important;
 }
 .markdown-source-view.mod-cm6 .cm-line {
-	margin-top: 0.1rem !important;
+	margin-top: 0 !important;
 }
 .markdown-preview-view, .markdown-rendered {
 	--h1-size: 1em !important;


### PR DESCRIPTION
Removing the top-margin here helps users select words in the last line of a document, and removes the separators between lines in a code block.